### PR TITLE
Pypi releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+# Upload python package to pypi server and github release.
+# Reference: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-to-pypi:
+    name: >-
+      Publish distribution to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nomad-simulation-apps
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ A repository for housing NOMAD's collection of simulation app plugins.
 
 This `nomad` plugin was generated with `Cookiecutter` along with `@nomad`'s [`cookiecutter-nomad-plugin`](https://github.com/FAIRmat-NFDI/cookiecutter-nomad-plugin) template.
 
+## Usage
+
+This package can be installed from PyPI:
+
+```sh
+pip install nomad-simulation-apps
+```
 
 ## Development
 
@@ -160,7 +167,7 @@ on the [PyPI documentation](https://packaging.python.org/en/latest/tutorials/pac
 
 ### Template update
 
-We use cruft to update the project based on template changes. A `cruft-update.yml` is included in Github workflows to automatically check for updates and create pull requests to apply updates. Follow the [instructions](https://github.blog/changelog/2022-05-03-github-actions-prevent-github-actions-from-creating-and-approving-pull-requests/) on how to enable Github Actions to create pull requests. 
+We use cruft to update the project based on template changes. A `cruft-update.yml` is included in Github workflows to automatically check for updates and create pull requests to apply updates. Follow the [instructions](https://github.blog/changelog/2022-05-03-github-actions-prevent-github-actions-from-creating-and-approving-pull-requests/) on how to enable Github Actions to create pull requests.
 
 To run the check for updates locally, follow the instructions on [`cruft` website](https://cruft.github.io/cruft/#updating-a-project).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 name = "nomad-simulation-apps"
 description = "A repository for housing NOMAD's collection of simulation app plugins."
-version = "0.1.0"
+dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [
@@ -32,6 +32,7 @@ dependencies = [
 
 [project.urls]
 Repository = "https://github.com/FAIRmat-NFDI/nomad-simulation-apps"
+Documentation = "https://fairmat-nfdi.github.io/nomad-app-plugins-simulation/"
 
 [project.optional-dependencies]
 dev = ["ruff", "pytest", "structlog"]
@@ -77,7 +78,7 @@ select = [
     "UP",
     # isort
     "I",
-    # pylint 
+    # pylint
     "PL",
 ]
 
@@ -109,6 +110,8 @@ package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools_scm]
 
 [project.entry-points.'nomad.plugin']
 alexandria_app = "nomad_simulation_apps.apps:alexandria_entry_point"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/FAIRmat-NFDI/nomad-simulation-apps"
+Repository = "https://github.com/FAIRmat-NFDI/nomad-app-plugins-simulation"
 Documentation = "https://fairmat-nfdi.github.io/nomad-app-plugins-simulation/"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Changes: 
- enabled dynamic versioning
- created a PyPI release of the package: https://pypi.org/project/nomad-simulation-apps/
- added and adapted `publish.yaml` from [here](https://github.com/FAIRmat-NFDI/nomad-utility-workflows/blob/develop/.github/workflows/publish.yml)  

I also added the deployment environment and allowed github as a trusted publisher for PyPI.